### PR TITLE
:bug: fix: ErrorCode에서 콜론이 아니라 세미콜론이어서 빌드되지 않는 에러 수정

### DIFF
--- a/business/src/main/java/com/emotionbank/business/global/error/ErrorCode.java
+++ b/business/src/main/java/com/emotionbank/business/global/error/ErrorCode.java
@@ -47,7 +47,7 @@ public enum ErrorCode {
 	// Terms
 	TERMS_CREATE_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "E-001", "약관을 생성할 수 있는 권한이 없습니다."),
 	TERMS_NOT_FOUND(HttpStatus.BAD_REQUEST, "E-002", "약관 정보가 없습니다."),
-	AGREEMENT_NOT_FOUND(HttpStatus.BAD_REQUEST, "G-001", "약관 동의 정보가 없습니다.");
+	AGREEMENT_NOT_FOUND(HttpStatus.BAD_REQUEST, "G-001", "약관 동의 정보가 없습니다."),
 
 	// Notification
 	NOTIFICATION_CREATE_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "N-001", "알림을 보낼 수 있는 권한이 없습니다");


### PR DESCRIPTION
## 📑 요약
Enum 사이가 세미콜론으로 되어있어 빌드되지 않는 에러를 수정했습니다.

## 📚 변경 내용
세미콜론을 콤마로 변경

## 🔢 이슈 번호
